### PR TITLE
Fix TOC icon alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,13 @@
     }
 
     #toc a i {
+      flex-shrink: 0;
+      display: inline-grid;
+      place-items: center;
+      width: 40px;
+      height: 40px;
+      border-radius: 12px;
+      background: rgba(63, 81, 181, 0.12);
       color: var(--primary);
       font-size: 1.2rem;
     }


### PR DESCRIPTION
## Summary
- ensure the table-of-contents icons render inside uniform containers
- prevent the icons from shifting by constraining their size and centering them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce074db1748331b721f179566c649c