### PR TITLE
Refine TOC icon alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,9 +122,12 @@
       height: 44px;
       border-radius: 14px;
       background: rgba(63, 81, 181, 0.12);
-      display: grid;
-      place-items: center;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       font-size: 1.2rem;
+      position: relative;
+      line-height: 1;
     }
 
     p {
@@ -159,8 +162,26 @@
     }
 
     #toc a i {
+      flex-shrink: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 40px;
+      border-radius: 12px;
+      background: rgba(63, 81, 181, 0.12);
       color: var(--primary);
       font-size: 1.2rem;
+      position: relative;
+      line-height: 1;
+    }
+
+    h2 i::before,
+    #toc a i::before {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
     }
 
     #toc a:hover {


### PR DESCRIPTION
## Summary
- convert the heading and TOC icon containers to flex-based alignment so the glyphs stay centered
- explicitly center the Font Awesome pseudo-elements within their badges to prevent visible offsets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce074db1748331b721f179566c649c