### PR TITLE
Add introduction page for Location Memo app

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,665 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Location Memo アプリ紹介</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    :root {
+      --primary: #3f51b5;
+      --primary-dark: #303f9f;
+      --accent: #ffb300;
+      --background: #f4f6fb;
+      --surface: #ffffff;
+      --text: #233044;
+      --muted: #5f6c86;
+      --border: rgba(63, 81, 181, 0.08);
+      --shadow: 0 30px 60px -45px rgba(35, 48, 68, 0.55);
+    }
+
+    body {
+      font-family: 'Noto Sans JP', sans-serif;
+      background: var(--background);
+      color: var(--text);
+      line-height: 1.7;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    header {
+      position: relative;
+      background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+      color: #fff;
+      padding: 64px 16px 120px;
+      text-align: center;
+      overflow: hidden;
+    }
+
+    header::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.18), transparent 62%);
+      opacity: 0.7;
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    header .inner {
+      position: relative;
+      z-index: 1;
+      max-width: 1000px;
+      margin: 0 auto;
+    }
+
+    header nav {
+      display: flex;
+      justify-content: flex-end;
+      gap: 12px;
+      margin-bottom: 32px;
+    }
+
+    header nav a {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 18px;
+      border-radius: 999px;
+      font-weight: 500;
+      font-size: 0.95rem;
+      color: rgba(255, 255, 255, 0.94);
+      text-decoration: none;
+      background: rgba(255, 255, 255, 0.12);
+      transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 14px 30px -18px rgba(0, 0, 0, 0.5);
+    }
+
+    header nav a:hover {
+      transform: translateY(-2px);
+      background: rgba(255, 255, 255, 0.2);
+      box-shadow: 0 16px 35px -16px rgba(0, 0, 0, 0.45);
+    }
+
+    header h1 {
+      font-size: clamp(2.4rem, 6vw, 3.2rem);
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      margin-bottom: 12px;
+    }
+
+    header p.lead {
+      font-size: 1.12rem;
+      max-width: 720px;
+      margin: 0 auto 36px;
+      color: rgba(255, 255, 255, 0.92);
+    }
+
+    .hero-meta {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 18px;
+      margin-bottom: 12px;
+    }
+
+    .hero-meta span {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.16);
+      font-size: 0.9rem;
+      letter-spacing: 0.04em;
+    }
+
+    main {
+      position: relative;
+      z-index: 2;
+      max-width: 1100px;
+      margin: -72px auto 96px;
+      padding: 0 16px;
+    }
+
+    section {
+      background: var(--surface);
+      border-radius: 26px;
+      padding: 36px;
+      margin-bottom: 28px;
+      border: 1px solid var(--border);
+      box-shadow: var(--shadow);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    section:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 36px 72px -48px rgba(35, 48, 68, 0.62);
+    }
+
+    h2 {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 1.65rem;
+      color: var(--primary);
+      margin-bottom: 22px;
+    }
+
+    h2 i {
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(63, 81, 181, 0.1);
+      color: var(--primary);
+    }
+
+    p {
+      color: var(--muted);
+      margin-bottom: 16px;
+    }
+
+    .feature-grid,
+    .card-grid,
+    .roadmap-grid,
+    .platform-grid,
+    .tech-grid {
+      display: grid;
+      gap: 20px;
+    }
+
+    .feature-grid {
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .feature-card {
+      border-radius: 20px;
+      padding: 24px;
+      background: linear-gradient(160deg, rgba(63, 81, 181, 0.08), rgba(63, 81, 181, 0.02));
+      border: 1px solid rgba(63, 81, 181, 0.12);
+      box-shadow: 0 24px 60px -52px rgba(35, 48, 68, 0.8);
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .feature-card i {
+      font-size: 1.8rem;
+      color: var(--primary);
+    }
+
+    .feature-card h3 {
+      font-size: 1.2rem;
+      color: var(--text);
+    }
+
+    .feature-card ul {
+      list-style: none;
+      color: var(--muted);
+      display: grid;
+      gap: 8px;
+      font-size: 0.95rem;
+    }
+
+    .card-grid {
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .card {
+      border-radius: 20px;
+      padding: 24px;
+      background: #fff;
+      border: 1px solid rgba(63, 81, 181, 0.12);
+      box-shadow: 0 20px 50px -48px rgba(35, 48, 68, 0.55);
+    }
+
+    .card h3 {
+      font-size: 1.15rem;
+      color: var(--text);
+      margin-bottom: 12px;
+    }
+
+    .card ul {
+      list-style: none;
+      display: grid;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .card strong {
+      color: var(--text);
+    }
+
+    .workflow {
+      display: grid;
+      gap: 12px;
+      list-style: none;
+      counter-reset: step;
+    }
+
+    .workflow li {
+      position: relative;
+      padding: 18px 18px 18px 54px;
+      border-radius: 16px;
+      background: rgba(63, 81, 181, 0.05);
+      border: 1px solid rgba(63, 81, 181, 0.12);
+      color: var(--muted);
+    }
+
+    .workflow li::before {
+      counter-increment: step;
+      content: counter(step);
+      position: absolute;
+      left: 18px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 26px;
+      height: 26px;
+      border-radius: 50%;
+      background: var(--primary);
+      color: #fff;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.85rem;
+      font-weight: 700;
+      box-shadow: 0 10px 25px -14px rgba(63, 81, 181, 0.7);
+    }
+
+    .platform-grid {
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .platform-card {
+      padding: 24px;
+      border-radius: 20px;
+      border: 1px solid rgba(63, 81, 181, 0.12);
+      background: linear-gradient(160deg, rgba(255, 255, 255, 1), rgba(63, 81, 181, 0.05));
+      color: var(--muted);
+      box-shadow: 0 20px 52px -50px rgba(35, 48, 68, 0.65);
+    }
+
+    .platform-card h3 {
+      font-size: 1.15rem;
+      color: var(--text);
+      margin-bottom: 12px;
+    }
+
+    .tech-grid {
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .roadmap-grid {
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+
+    .roadmap-card {
+      border-radius: 20px;
+      padding: 24px;
+      border: 1px solid rgba(63, 81, 181, 0.12);
+      background: #fff;
+      box-shadow: 0 20px 54px -50px rgba(35, 48, 68, 0.6);
+    }
+
+    .roadmap-card h3 {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 1.12rem;
+      color: var(--text);
+      margin-bottom: 12px;
+    }
+
+    .roadmap-card h3 i {
+      font-size: 1.2rem;
+      background: rgba(63, 81, 181, 0.12);
+      width: 38px;
+      height: 38px;
+    }
+
+    .roadmap-card ul {
+      list-style: none;
+      display: grid;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .cta {
+      text-align: center;
+    }
+
+    .cta p {
+      font-size: 1.05rem;
+      color: var(--muted);
+      margin-bottom: 24px;
+    }
+
+    .cta-buttons {
+      display: inline-flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      justify-content: center;
+    }
+
+    .cta-buttons a {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 14px 24px;
+      border-radius: 999px;
+      font-weight: 600;
+      text-decoration: none;
+      color: #fff;
+      background: var(--primary);
+      box-shadow: 0 18px 36px -24px rgba(63, 81, 181, 0.7);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .cta-buttons a.secondary {
+      background: rgba(63, 81, 181, 0.12);
+      color: var(--primary);
+      box-shadow: none;
+      border: 1px solid rgba(63, 81, 181, 0.2);
+    }
+
+    .cta-buttons a:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 24px 46px -26px rgba(63, 81, 181, 0.7);
+    }
+
+    .cta-buttons a.secondary:hover {
+      box-shadow: 0 16px 32px -26px rgba(63, 81, 181, 0.5);
+    }
+
+    footer {
+      text-align: center;
+      padding: 42px 16px;
+      color: rgba(35, 48, 68, 0.65);
+      font-size: 0.9rem;
+    }
+
+    #backToTop {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      border: none;
+      background: var(--primary);
+      color: #fff;
+      box-shadow: 0 18px 42px -24px rgba(63, 81, 181, 0.65);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s ease, transform 0.3s ease;
+      z-index: 10;
+    }
+
+    #backToTop.is-visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateY(-4px);
+    }
+
+    @media (max-width: 768px) {
+      header nav {
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
+      section {
+        padding: 28px 22px;
+        border-radius: 22px;
+      }
+
+      .hero-meta {
+        gap: 12px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="inner">
+      <nav aria-label="ページナビゲーション">
+        <a href="index.html"><i class="fas fa-download"></i> インストールガイドへ</a>
+        <a href="https://github.com/akiii2024/location_memo" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub</a>
+      </nav>
+      <h1>Location Memo アプリ紹介</h1>
+      <p class="lead">フィールドワークや野外調査の現場で、位置情報と共にメモ・写真・音声をまとめて記録できるオールインワンの記録管理アプリです。</p>
+      <div class="hero-meta">
+        <span><i class="fas fa-globe"></i> Android / iOS / Web / デスクトップ</span>
+        <span><i class="fas fa-robot"></i> AI支援で記録を自動化</span>
+        <span><i class="fas fa-cloud-upload-alt"></i> データバックアップ &amp; 復元</span>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="overview">
+      <h2><i class="fas fa-compass"></i> Location Memoとは</h2>
+      <p>Location Memoは、独自地図へのピン配置やAIアシスタントを組み合わせて、フィールドワークの記録を一元管理できるFlutter製アプリです。写真・音声・詳細情報を位置情報に紐付け、調査結果を後からすぐに振り返れるようにデザインされています。</p>
+      <p>地図画像のアップロードやカテゴリ管理、PDFレポートの出力、JSONバックアップなど、調査プロジェクトに必要な情報管理を丸ごとサポートします。ネイティブアプリとPWAの両方に対応し、現場・研究室・リモート作業など利用シーンを選びません。</p>
+    </section>
+
+    <section id="features">
+      <h2><i class="fas fa-layer-group"></i> 主な機能</h2>
+      <div class="feature-grid">
+        <div class="feature-card">
+          <i class="fas fa-map-marker-alt"></i>
+          <h3>位置情報付きメモ</h3>
+          <ul>
+            <li>緯度・経度や発見者、標本番号などの詳細を1か所で管理</li>
+            <li>メモごとに写真を複数添付、音声メモも録音・再生</li>
+            <li>カテゴリ分けと検索機能で後から目的の記録を素早く発見</li>
+          </ul>
+        </div>
+        <div class="feature-card">
+          <i class="fas fa-map"></i>
+          <h3>カスタム地図とピン管理</h3>
+          <ul>
+            <li>PDFや画像の地図を取り込み、任意の場所にピンを配置</li>
+            <li>複数地図をプロジェクトごとに管理し、ピン一覧で全体を俯瞰</li>
+            <li>詳細な位置選択画面で正確な座標を指定可能</li>
+          </ul>
+        </div>
+        <div class="feature-card">
+          <i class="fas fa-robot"></i>
+          <h3>AIアシスタント</h3>
+          <ul>
+            <li>撮影した写真を分析してメモ内容の下書きを自動生成</li>
+            <li>音声録音から内容を整理、フィールドメモ作成を効率化</li>
+            <li>アプリ内のAIチャットで記録の改善提案や質問対応</li>
+          </ul>
+        </div>
+        <div class="feature-card">
+          <i class="fas fa-database"></i>
+          <h3>データ保護と共有</h3>
+          <ul>
+            <li>SQLite / Hiveでデータを堅牢に保存し、PDFレポートも生成</li>
+            <li>JSONバックアップと個別地図のエクスポートで確実に復元</li>
+            <li>GitHub PagesによるPWAデプロイにも対応</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="scenarios">
+      <h2><i class="fas fa-seedling"></i> 利用シナリオ</h2>
+      <div class="card-grid">
+        <div class="card">
+          <h3>野外調査・環境観測</h3>
+          <ul>
+            <li>採集地点ごとの標本情報や写真を即時記録</li>
+            <li>音声メモで現場の状況を逃さず保存</li>
+            <li>後からPDFにまとめてチームで共有</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>文化財・建築物調査</h3>
+          <ul>
+            <li>独自の図面を地図として読み込み、ピンで観察箇所を整理</li>
+            <li>発見時刻や担当者などの詳細をメモに紐付け</li>
+            <li>カテゴリや検索機能で資料整理もスムーズ</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>教育・ワークショップ</h3>
+          <ul>
+            <li>学外学習での記録教材として活用</li>
+            <li>AIアシスタントが振り返りの観点を提示</li>
+            <li>データをエクスポートしてレポート課題に応用</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="workflow">
+      <h2><i class="fas fa-route"></i> 利用の流れ</h2>
+      <ul class="workflow">
+        <li>GitHubからアプリを入手し、Flutterでセットアップ。必要に応じてAI機能のAPIキーを設定します。</li>
+        <li>プロジェクトの地図画像をアップロードし、ピンを配置してメモを追加。</li>
+        <li>写真や音声を添付し、AIアシスタントを使って内容を素早く整理。</li>
+        <li>検索やカテゴリで記録を管理し、バックアップやPDFレポートで成果を共有します。</li>
+      </ul>
+    </section>
+
+    <section id="platforms">
+      <h2><i class="fas fa-laptop-code"></i> 対応プラットフォームと体験</h2>
+      <div class="platform-grid">
+        <div class="platform-card">
+          <h3><i class="fab fa-android"></i> Android / iOS</h3>
+          <p>Flutterネイティブとして動作し、オフラインでもデータを保持。音声録音やカメラなど端末機能を最大限活用します。</p>
+        </div>
+        <div class="platform-card">
+          <h3><i class="fas fa-chrome"></i> Web / PWA</h3>
+          <p>ブラウザからホーム画面へインストールし、ほぼネイティブと同等の体験。オフライン対応やスプラッシュスクリーンも実装済みです。</p>
+        </div>
+        <div class="platform-card">
+          <h3><i class="fas fa-desktop"></i> デスクトップ</h3>
+          <p>Windows / macOS / Linuxにも対応し、研究室やオフィスでも同じデータを扱えます。共有作業や資料作成が容易です。</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="tech">
+      <h2><i class="fas fa-code"></i> 技術スタック</h2>
+      <div class="tech-grid">
+        <div class="card">
+          <h3>アプリケーション</h3>
+          <ul>
+            <li><strong>フレームワーク:</strong> Flutter 3.5+</li>
+            <li><strong>状態管理:</strong> Provider</li>
+            <li><strong>データベース:</strong> SQLite（ネイティブ） / Hive（Web）</li>
+            <li><strong>UI:</strong> ダークモード、チュートリアル、SVGアイコン</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>データ連携・AI</h3>
+          <ul>
+            <li><strong>バックアップ:</strong> JSONエクスポート / 個別地図バックアップ</li>
+            <li><strong>PDF生成:</strong> pdf, printing</li>
+            <li><strong>AI機能:</strong> Google Generative AI (Gemini)</li>
+            <li><strong>音声録音:</strong> flutter_sound / WebAudioService</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>周辺機能</h3>
+          <ul>
+            <li><strong>ファイル管理:</strong> file_picker, path_provider</li>
+            <li><strong>データ共有:</strong> share_plus, url_launcher</li>
+            <li><strong>通信:</strong> http</li>
+            <li><strong>PWA:</strong> Web App Manifest, Service Worker</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="roadmap">
+      <h2><i class="fas fa-flag-checkered"></i> 開発状況</h2>
+      <div class="roadmap-grid">
+        <div class="roadmap-card">
+          <h3><i class="fas fa-check-circle"></i> 完全実装済み</h3>
+          <ul>
+            <li>カスタム地図の読み込みとピン配置</li>
+            <li>音声録音・再生およびAIアシスタント</li>
+            <li>バックアップ・復元・PDF出力</li>
+            <li>ライト / ダークテーマ対応</li>
+          </ul>
+        </div>
+        <div class="roadmap-card">
+          <h3><i class="fas fa-exclamation-circle"></i> 制限事項</h3>
+          <ul>
+            <li>現在は手動で位置情報を指定（GPSは一時的に無効化）</li>
+            <li>通知機能はUIのみ実装済み</li>
+            <li>Web環境では一部機能に制約が発生する可能性があります</li>
+          </ul>
+        </div>
+        <div class="roadmap-card">
+          <h3><i class="fas fa-lightbulb"></i> 今後の予定</h3>
+          <ul>
+            <li>GPS位置情報機能の再有効化</li>
+            <li>グリッド座標や手動座標指定の拡張</li>
+            <li>オンライン共有機能などコラボレーションの強化</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="cta" class="cta">
+      <h2><i class="fas fa-rocket"></i> 今すぐ体験しましょう</h2>
+      <p>Location Memoは、フィールドワークの「記録」「管理」「共有」をワンストップで実現します。導入方法はインストールガイドから確認でき、GitHubで最新の開発状況を追跡できます。</p>
+      <div class="cta-buttons">
+        <a href="index.html"><i class="fas fa-download"></i> インストール手順を見る</a>
+        <a class="secondary" href="https://github.com/akiii2024/location_memo" target="_blank" rel="noopener"><i class="fab fa-github"></i> リポジトリを確認</a>
+      </div>
+    </section>
+  </main>
+
+  <button id="backToTop" aria-label="トップへ戻る">
+    <i class="fas fa-arrow-up"></i>
+  </button>
+
+  <footer>
+    &copy; 2024 Location Memo Project
+  </footer>
+
+  <script>
+    const backToTop = document.getElementById('backToTop');
+    const toggleBackToTop = () => {
+      if (!backToTop) return;
+      if (window.scrollY > 400) {
+        backToTop.classList.add('is-visible');
+      } else {
+        backToTop.classList.remove('is-visible');
+      }
+    };
+
+    if (backToTop) {
+      backToTop.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+    }
+
+    toggleBackToTop();
+    window.addEventListener('scroll', toggleBackToTop);
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -58,6 +58,35 @@
       margin: 0 auto;
     }
 
+    .top-nav {
+      display: flex;
+      justify-content: flex-end;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 20px;
+    }
+
+    .top-nav a {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 18px;
+      border-radius: 999px;
+      font-size: 0.95rem;
+      font-weight: 500;
+      color: rgba(255, 255, 255, 0.95);
+      text-decoration: none;
+      background: rgba(255, 255, 255, 0.14);
+      box-shadow: 0 14px 28px -18px rgba(0, 0, 0, 0.45);
+      transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .top-nav a:hover {
+      transform: translateY(-2px);
+      background: rgba(255, 255, 255, 0.22);
+      box-shadow: 0 18px 36px -20px rgba(0, 0, 0, 0.45);
+    }
+
     .header-badge {
       display: inline-flex;
       align-items: center;
@@ -414,6 +443,10 @@
     }
 
     @media (max-width: 768px) {
+      .top-nav {
+        justify-content: center;
+      }
+
       header {
         padding: 56px 16px 96px;
       }
@@ -456,6 +489,10 @@
 <body>
   <header>
     <div class="header-inner">
+      <nav class="top-nav" aria-label="補助ナビゲーション">
+        <a href="about.html"><i class="fas fa-info-circle"></i> アプリ紹介</a>
+        <a href="https://github.com/akiii2024/location_memo" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub</a>
+      </nav>
       <span class="header-badge"><i class="fas fa-map-marker-alt"></i> location_memo</span>
       <h1>インストールガイド</h1>
       <p class="lead">お使いの端末に合わせた最適なインストール手順をまとめました。下記の目次から、該当する項目をご確認ください。</p>


### PR DESCRIPTION
## Summary
- create a standalone introduction page that presents Location Memo's purpose, key features, supported platforms, tech stack, and roadmap
- add a lightweight navigation shortcut on the existing install guide so visitors can jump to the new overview page or the GitHub repository

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce59278e88833192e35aeecd867477