### PR TITLE
Fix heading alignment and add usage guide page

### DIFF
--- a/about.html
+++ b/about.html
@@ -146,28 +146,39 @@
     }
 
     h2 {
-      display: flex;
-      align-items: center;
-      gap: 12px;
+      position: relative;
+      padding-left: 68px;
       font-size: 1.65rem;
       color: var(--primary);
       margin-bottom: 22px;
+      line-height: 1.4;
+      display: block;
+      min-height: 48px;
     }
 
     h2 i {
-      width: 44px;
-      height: 44px;
-      border-radius: 50%;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
+      position: absolute;
+      left: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
+      display: grid;
+      place-items: center;
       background: rgba(63, 81, 181, 0.1);
       color: var(--primary);
+      line-height: 1;
+      box-shadow: 0 18px 32px -28px rgba(63, 81, 181, 0.65);
     }
 
     p {
       color: var(--muted);
       margin-bottom: 16px;
+    }
+
+    section > p {
+      margin-left: 68px;
     }
 
     .feature-grid,
@@ -432,6 +443,36 @@
       .hero-meta {
         gap: 12px;
       }
+
+      h2 {
+        padding-left: 60px;
+        font-size: 1.45rem;
+      }
+
+      h2 i {
+        width: 44px;
+        height: 44px;
+      }
+
+      section > p {
+        margin-left: 60px;
+      }
+    }
+
+    @media (max-width: 520px) {
+      h2 {
+        padding-left: 54px;
+        font-size: 1.3rem;
+      }
+
+      h2 i {
+        width: 38px;
+        height: 38px;
+      }
+
+      section > p {
+        margin-left: 54px;
+      }
     }
   </style>
 </head>
@@ -440,6 +481,7 @@
     <div class="inner">
       <nav aria-label="ページナビゲーション">
         <a href="index.html"><i class="fas fa-download"></i> インストールガイドへ</a>
+        <a href="usage.html"><i class="fas fa-book-open"></i> 使い方ガイド</a>
         <a href="https://github.com/akiii2024/location_memo" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub</a>
       </nav>
       <h1>Location Memo アプリ紹介</h1>

--- a/index.html
+++ b/index.html
@@ -139,30 +139,39 @@
     }
 
     h2 {
-      display: flex;
-      align-items: center;
-      gap: 12px;
+      position: relative;
+      padding-left: 64px;
       font-size: 1.6rem;
       margin-bottom: 24px;
       color: var(--primary);
+      line-height: 1.4;
+      display: block;
+      min-height: 44px;
     }
 
     h2 i {
+      position: absolute;
+      left: 0;
+      top: 50%;
+      transform: translateY(-50%);
       width: 44px;
       height: 44px;
       border-radius: 14px;
       background: rgba(63, 81, 181, 0.12);
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
+      display: grid;
+      place-items: center;
       font-size: 1.2rem;
-      position: relative;
+      color: var(--primary);
       line-height: 1;
     }
 
     p {
       color: var(--muted);
       margin-bottom: 1rem;
+    }
+
+    section > p {
+      margin-left: 64px;
     }
 
     #toc ul {
@@ -456,6 +465,10 @@
         border-radius: 20px;
       }
 
+      section > p {
+        margin-left: 60px;
+      }
+
       .step-list li {
         padding-left: 3rem;
       }
@@ -477,6 +490,16 @@
 
       h2 {
         font-size: 1.4rem;
+        padding-left: 56px;
+      }
+
+      h2 i {
+        width: 38px;
+        height: 38px;
+      }
+
+      section > p {
+        margin-left: 54px;
       }
 
       #backToTop {
@@ -491,6 +514,7 @@
     <div class="header-inner">
       <nav class="top-nav" aria-label="補助ナビゲーション">
         <a href="about.html"><i class="fas fa-info-circle"></i> アプリ紹介</a>
+        <a href="usage.html"><i class="fas fa-book-open"></i> 使い方ガイド</a>
         <a href="https://github.com/akiii2024/location_memo" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub</a>
       </nav>
       <span class="header-badge"><i class="fas fa-map-marker-alt"></i> location_memo</span>

--- a/usage.html
+++ b/usage.html
@@ -1,0 +1,556 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Location Memo 使い方ガイド</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    :root {
+      --primary: #3f51b5;
+      --primary-dark: #303f9f;
+      --accent: #ffb74d;
+      --background: #f4f6fb;
+      --surface: #ffffff;
+      --text: #233044;
+      --muted: #5f6c86;
+      --border: rgba(63, 81, 181, 0.08);
+      --shadow: 0 34px 70px -48px rgba(35, 48, 68, 0.58);
+    }
+
+    body {
+      font-family: 'Noto Sans JP', sans-serif;
+      background: var(--background);
+      color: var(--text);
+      line-height: 1.7;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    header {
+      position: relative;
+      z-index: 0;
+      padding: 72px 16px 120px;
+      background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+      color: #fff;
+      text-align: center;
+      overflow: hidden;
+    }
+
+    header::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.2), transparent 60%);
+      opacity: 0.65;
+      pointer-events: none;
+      z-index: -1;
+    }
+
+    .header-inner {
+      position: relative;
+      max-width: 960px;
+      margin: 0 auto;
+    }
+
+    .top-nav {
+      display: flex;
+      justify-content: flex-end;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 24px;
+    }
+
+    .top-nav a {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 18px;
+      border-radius: 999px;
+      font-size: 0.95rem;
+      font-weight: 500;
+      color: rgba(255, 255, 255, 0.95);
+      text-decoration: none;
+      background: rgba(255, 255, 255, 0.14);
+      box-shadow: 0 14px 28px -18px rgba(0, 0, 0, 0.45);
+      transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .top-nav a[aria-current="page"] {
+      background: rgba(255, 255, 255, 0.24);
+      box-shadow: 0 16px 36px -18px rgba(0, 0, 0, 0.48);
+    }
+
+    .top-nav a:hover {
+      transform: translateY(-2px);
+      background: rgba(255, 255, 255, 0.22);
+      box-shadow: 0 18px 36px -20px rgba(0, 0, 0, 0.45);
+    }
+
+    header h1 {
+      font-size: clamp(2.2rem, 6vw, 3rem);
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      margin-bottom: 12px;
+    }
+
+    header .lead {
+      font-size: 1.1rem;
+      max-width: 680px;
+      margin: 0 auto 36px;
+      color: rgba(255, 255, 255, 0.94);
+    }
+
+    .hero-points {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 16px;
+    }
+
+    .hero-points span {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.16);
+      font-size: 0.9rem;
+      letter-spacing: 0.04em;
+    }
+
+    main {
+      position: relative;
+      z-index: 1;
+      max-width: 960px;
+      margin: -72px auto 96px;
+      padding: 0 16px;
+    }
+
+    section {
+      background: var(--surface);
+      border-radius: 24px;
+      padding: 32px;
+      margin-bottom: 32px;
+      border: 1px solid var(--border);
+      box-shadow: var(--shadow);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    section:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 36px 78px -54px rgba(35, 48, 68, 0.6);
+    }
+
+    h2 {
+      position: relative;
+      padding-left: 64px;
+      font-size: 1.65rem;
+      margin-bottom: 24px;
+      color: var(--primary);
+      line-height: 1.4;
+      display: block;
+      min-height: 48px;
+    }
+
+    h2 i {
+      position: absolute;
+      left: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
+      background: rgba(63, 81, 181, 0.1);
+      display: grid;
+      place-items: center;
+      font-size: 1.2rem;
+      color: var(--primary);
+      line-height: 1;
+      box-shadow: 0 18px 32px -28px rgba(63, 81, 181, 0.6);
+    }
+
+    h2 i::before {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+
+    p {
+      color: var(--muted);
+      margin-bottom: 1rem;
+    }
+
+    section > p {
+      margin-left: 64px;
+    }
+
+    .step-list {
+      list-style: none;
+      counter-reset: step;
+      display: grid;
+      gap: 20px;
+      padding: 0;
+      margin: 0;
+    }
+
+    .step-list li {
+      counter-increment: step;
+      position: relative;
+      padding-left: 3.4rem;
+    }
+
+    .step-list li::before {
+      content: counter(step);
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 1rem;
+      background: var(--primary);
+      color: #fff;
+      display: grid;
+      place-items: center;
+      font-weight: 700;
+      box-shadow: 0 16px 34px -22px rgba(63, 81, 181, 0.75);
+    }
+
+    .feature-columns {
+      display: grid;
+      gap: 24px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .usage-card {
+      border-radius: 20px;
+      padding: 24px;
+      border: 1px solid rgba(63, 81, 181, 0.12);
+      background: linear-gradient(165deg, rgba(63, 81, 181, 0.08), rgba(63, 81, 181, 0.02));
+      box-shadow: 0 24px 64px -48px rgba(35, 48, 68, 0.65);
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .usage-card h3 {
+      font-size: 1.15rem;
+      color: var(--primary);
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .usage-card h3 i {
+      color: var(--accent);
+    }
+
+    .usage-card ul {
+      padding-left: 1.1rem;
+      color: var(--muted);
+      display: grid;
+      gap: 6px;
+    }
+
+    .tip-list {
+      display: grid;
+      gap: 16px;
+    }
+
+    .tip-item {
+      border-radius: 16px;
+      padding: 20px;
+      background: #f6f8ff;
+      border: 1px solid rgba(63, 81, 181, 0.15);
+      display: flex;
+      gap: 12px;
+      align-items: flex-start;
+    }
+
+    .tip-item i {
+      font-size: 1.25rem;
+      color: var(--primary);
+    }
+
+    .cta-box {
+      border-radius: 22px;
+      background: linear-gradient(135deg, rgba(63, 81, 181, 0.14), rgba(63, 81, 181, 0.05));
+      padding: 28px;
+      display: grid;
+      gap: 18px;
+      text-align: center;
+    }
+
+    .cta-actions {
+      display: flex;
+      justify-content: center;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    .cta-actions a {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 22px;
+      border-radius: 999px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .cta-actions a.primary {
+      background: var(--primary);
+      color: #fff;
+      box-shadow: 0 18px 40px -24px rgba(63, 81, 181, 0.75);
+    }
+
+    .cta-actions a.secondary {
+      background: rgba(63, 81, 181, 0.1);
+      color: var(--primary);
+      border: 1px solid rgba(63, 81, 181, 0.2);
+    }
+
+    .cta-actions a:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 20px 44px -28px rgba(63, 81, 181, 0.65);
+    }
+
+    footer {
+      text-align: center;
+      padding: 42px 16px;
+      color: rgba(35, 48, 68, 0.65);
+      font-size: 0.9rem;
+    }
+
+    #backToTop {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      border: none;
+      background: var(--primary);
+      color: #fff;
+      box-shadow: 0 18px 42px -24px rgba(63, 81, 181, 0.65);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s ease, transform 0.3s ease;
+      z-index: 10;
+    }
+
+    #backToTop:hover {
+      transform: translateY(-3px);
+    }
+
+    #backToTop.is-visible {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    @media (max-width: 768px) {
+      .top-nav {
+        justify-content: center;
+      }
+
+      section {
+        padding: 28px;
+      }
+
+      h2 {
+        padding-left: 60px;
+        font-size: 1.45rem;
+      }
+
+      h2 i {
+        width: 44px;
+        height: 44px;
+      }
+
+      section > p {
+        margin-left: 60px;
+      }
+
+      .step-list li {
+        padding-left: 3rem;
+      }
+
+      .step-list li::before {
+        width: 2.3rem;
+        height: 2.3rem;
+      }
+    }
+
+    @media (max-width: 520px) {
+      header {
+        padding: 60px 16px 96px;
+      }
+
+      section {
+        padding: 24px;
+      }
+
+      h2 {
+        padding-left: 54px;
+        font-size: 1.3rem;
+      }
+
+      h2 i {
+        width: 38px;
+        height: 38px;
+      }
+
+      section > p {
+        margin-left: 54px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <nav class="top-nav" aria-label="補助ナビゲーション">
+        <a href="index.html"><i class="fas fa-download"></i> インストールガイド</a>
+        <a href="about.html"><i class="fas fa-info-circle"></i> アプリ紹介</a>
+        <a href="usage.html" aria-current="page"><i class="fas fa-book-open"></i> 使い方ガイド</a>
+        <a href="https://github.com/akiii2024/location_memo" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub</a>
+      </nav>
+      <h1>Location Memo 使い方ガイド</h1>
+      <p class="lead">現地での記録からチーム共有まで、Location Memoをスムーズに活用するための基本的な流れとコツを紹介します。</p>
+      <div class="hero-points">
+        <span><i class="fas fa-shoe-prints"></i> 現場での素早い記録</span>
+        <span><i class="fas fa-sync"></i> AIアシスタントで整理</span>
+        <span><i class="fas fa-share-alt"></i> チームへの共有を効率化</span>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="getting-started">
+      <h2><i class="fas fa-compass"></i> 使い始める前に</h2>
+      <p>Location Memoは、プロジェクト単位で地図とメモを整理できるフィールドワーク支援アプリです。まずはアプリをインストールし、利用したい地図データや共有したいメンバーを準備しておきましょう。</p>
+      <p>アプリを初めて起動すると、サンプルプロジェクトが表示されます。実際の調査に合わせてプロジェクトを新規作成し、自分たちのワークフローに沿ったカテゴリやタグを設定することで、後から情報を探しやすくなります。</p>
+    </section>
+
+    <section id="setup-flow">
+      <h2><i class="fas fa-route"></i> 基本設定の流れ</h2>
+      <ol class="step-list">
+        <li>
+          <p>ホーム画面で「新しいプロジェクト」を選択し、プロジェクト名と概要を入力します。必要に応じてカテゴリやタグも設定しましょう。</p>
+        </li>
+        <li>
+          <p>プロジェクトに使用する地図画像（JPG / PNG / PDF）をアップロードし、縮尺や方位を確認します。既存の地図にピンを配置する場合は、基準点を設定すると精度が上がります。</p>
+        </li>
+        <li>
+          <p>記録に必要なAI機能（写真解析や要約など）を利用する場合は、設定画面からAPIキーを登録します。チームで共有する場合はバックアップ保存先も合わせて設定しましょう。</p>
+        </li>
+      </ol>
+    </section>
+
+    <section id="field-recording">
+      <h2><i class="fas fa-map-marker-alt"></i> フィールドでの記録手順</h2>
+      <div class="feature-columns">
+        <div class="usage-card">
+          <h3><i class="fas fa-location-dot"></i> ピンを配置</h3>
+          <p>地図上の任意の地点をタップしてピンを追加します。位置情報の微調整は座標指定画面から行えます。</p>
+          <ul>
+            <li>ピンにはカテゴリやタグを付けて分類</li>
+            <li>オフライン環境でも一時保存が可能</li>
+          </ul>
+        </div>
+        <div class="usage-card">
+          <h3><i class="fas fa-camera"></i> メディアを添付</h3>
+          <p>写真・音声・テキストメモをピンに紐付けましょう。音声は自動でテキスト化してAIが要約案を提示します。</p>
+          <ul>
+            <li>複数の写真を一括で取り込み可能</li>
+            <li>メモにはMarkdown形式で記述できます</li>
+          </ul>
+        </div>
+        <div class="usage-card">
+          <h3><i class="fas fa-robot"></i> AIで整理</h3>
+          <p>収集した情報をAIアシスタントに渡すと、記録の要約や次のアクション案が返ってきます。質問にもチャット形式で回答します。</p>
+          <ul>
+            <li>自動生成された内容は後から編集可能</li>
+            <li>タグ提案で分類の手間を削減</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="share-tips">
+      <h2><i class="fas fa-people-arrows"></i> 共有・振り返りのコツ</h2>
+      <div class="tip-list">
+        <div class="tip-item">
+          <i class="fas fa-cloud-upload-alt"></i>
+          <div>
+            <h3>バックアップと同期</h3>
+            <p>定期的にJSONバックアップを取り、クラウドストレージに保存しておくと端末トラブル時も安心です。チーム共有では同じバックアップをインポートすることで情報を揃えられます。</p>
+          </div>
+        </div>
+        <div class="tip-item">
+          <i class="fas fa-file-pdf"></i>
+          <div>
+            <h3>レポート出力</h3>
+            <p>調査結果はPDFレポートにまとめて共有できます。写真付きで時系列に整理されるため、会議や報告書作成の下書きとして活用できます。</p>
+          </div>
+        </div>
+        <div class="tip-item">
+          <i class="fas fa-filter"></i>
+          <div>
+            <h3>検索とフィルター</h3>
+            <p>カテゴリやタグ、記録者などでフィルターすると、必要な記録に素早くアクセスできます。よく使う検索条件はお気に入りに登録しておくと便利です。</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="cta" class="cta-box">
+      <h2><i class="fas fa-rocket"></i> 次の一歩へ</h2>
+      <p>インストールがまだの方はインストールガイドを、アプリの全体像を知りたい方はアプリ紹介ページをご覧ください。Location Memoを使って現場の記録をもっとスムーズにしましょう。</p>
+      <div class="cta-actions">
+        <a class="primary" href="index.html"><i class="fas fa-download"></i> インストール手順を見る</a>
+        <a class="secondary" href="about.html"><i class="fas fa-info-circle"></i> アプリの特徴を知る</a>
+      </div>
+    </section>
+  </main>
+
+  <button id="backToTop" aria-label="トップへ戻る">
+    <i class="fas fa-arrow-up"></i>
+  </button>
+
+  <footer>
+    &copy; 2024 Location Memo Project
+  </footer>
+
+  <script>
+    const backToTop = document.getElementById('backToTop');
+    if (backToTop) {
+      backToTop.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+
+      window.addEventListener('scroll', () => {
+        if (window.scrollY > 320) {
+          backToTop.classList.add('is-visible');
+        } else {
+          backToTop.classList.remove('is-visible');
+        }
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- adjust section heading layout so icons no longer push body text out of alignment
- add direct-child paragraph spacing rules to keep headings and body copy lined up across breakpoints
- create a new usage.html page that explains the basic workflow, tips, and includes navigation links from other pages

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ceccb86f50833185025b1e2b29704f