### PR TITLE
更新履歴ページを追加

### DIFF
--- a/about.html
+++ b/about.html
@@ -482,6 +482,7 @@
       <nav aria-label="ページナビゲーション">
         <a href="index.html"><i class="fas fa-download"></i> インストールガイドへ</a>
         <a href="usage.html"><i class="fas fa-book-open"></i> 使い方ガイド</a>
+        <a href="updates.html"><i class="fas fa-clock-rotate-left"></i> 更新履歴</a>
         <a href="https://github.com/akiii2024/location_memo" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub</a>
       </nav>
       <h1>Location Memo アプリ紹介</h1>

--- a/index.html
+++ b/index.html
@@ -515,6 +515,7 @@
       <nav class="top-nav" aria-label="補助ナビゲーション">
         <a href="about.html"><i class="fas fa-info-circle"></i> アプリ紹介</a>
         <a href="usage.html"><i class="fas fa-book-open"></i> 使い方ガイド</a>
+        <a href="updates.html"><i class="fas fa-clock-rotate-left"></i> 更新履歴</a>
         <a href="https://github.com/akiii2024/location_memo" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub</a>
       </nav>
       <span class="header-badge"><i class="fas fa-map-marker-alt"></i> location_memo</span>

--- a/updates.html
+++ b/updates.html
@@ -1,0 +1,663 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Location Memo 更新履歴</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    :root {
+      --primary: #3f51b5;
+      --primary-dark: #303f9f;
+      --accent: #ffb74d;
+      --background: #f4f6fb;
+      --surface: #ffffff;
+      --text: #233044;
+      --muted: #5f6c86;
+      --border: rgba(63, 81, 181, 0.1);
+      --shadow: 0 34px 70px -48px rgba(35, 48, 68, 0.58);
+    }
+
+    body {
+      font-family: 'Noto Sans JP', sans-serif;
+      background: var(--background);
+      color: var(--text);
+      line-height: 1.7;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    header {
+      position: relative;
+      z-index: 0;
+      padding: 72px 16px 118px;
+      background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+      color: #fff;
+      text-align: center;
+      overflow: hidden;
+    }
+
+    header::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.22), transparent 62%);
+      opacity: 0.7;
+      pointer-events: none;
+      z-index: -1;
+    }
+
+    .header-inner {
+      position: relative;
+      max-width: 1040px;
+      margin: 0 auto;
+      z-index: 1;
+    }
+
+    .top-nav {
+      display: flex;
+      justify-content: flex-end;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 24px;
+    }
+
+    .top-nav a {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 18px;
+      border-radius: 999px;
+      font-size: 0.95rem;
+      font-weight: 500;
+      color: rgba(255, 255, 255, 0.95);
+      text-decoration: none;
+      background: rgba(255, 255, 255, 0.14);
+      box-shadow: 0 14px 28px -18px rgba(0, 0, 0, 0.45);
+      transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .top-nav a[aria-current="page"] {
+      background: rgba(255, 255, 255, 0.26);
+      box-shadow: 0 18px 36px -18px rgba(0, 0, 0, 0.5);
+    }
+
+    .top-nav a:hover {
+      transform: translateY(-2px);
+      background: rgba(255, 255, 255, 0.22);
+      box-shadow: 0 18px 36px -20px rgba(0, 0, 0, 0.45);
+    }
+
+    header h1 {
+      font-size: clamp(2.2rem, 6vw, 3.1rem);
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      margin-bottom: 14px;
+    }
+
+    header .lead {
+      font-size: 1.08rem;
+      max-width: 720px;
+      margin: 0 auto 32px;
+      color: rgba(255, 255, 255, 0.92);
+    }
+
+    .header-stats {
+      display: flex;
+      justify-content: center;
+      gap: 18px;
+      flex-wrap: wrap;
+    }
+
+    .header-stats span {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 18px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.16);
+      font-size: 0.9rem;
+      letter-spacing: 0.03em;
+    }
+
+    main {
+      position: relative;
+      z-index: 1;
+      max-width: 1040px;
+      margin: -68px auto 96px;
+      padding: 0 16px;
+    }
+
+    section {
+      background: var(--surface);
+      border-radius: 26px;
+      padding: 36px;
+      margin-bottom: 28px;
+      border: 1px solid var(--border);
+      box-shadow: var(--shadow);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    section:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 36px 78px -54px rgba(35, 48, 68, 0.62);
+    }
+
+    h2 {
+      position: relative;
+      padding-left: 68px;
+      font-size: 1.65rem;
+      color: var(--primary);
+      margin-bottom: 22px;
+      line-height: 1.4;
+      display: block;
+      min-height: 48px;
+    }
+
+    h2 i {
+      position: absolute;
+      left: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 44px;
+      height: 44px;
+      border-radius: 14px;
+      background: rgba(63, 81, 181, 0.12);
+      display: grid;
+      place-items: center;
+      font-size: 1.2rem;
+      color: var(--primary);
+      line-height: 1;
+    }
+
+    p {
+      color: var(--muted);
+      margin-bottom: 1rem;
+    }
+
+    .highlight-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 20px;
+      margin-top: 12px;
+    }
+
+    .highlight-card {
+      border-radius: 22px;
+      padding: 24px;
+      background: linear-gradient(160deg, rgba(63, 81, 181, 0.08), rgba(63, 81, 181, 0.02));
+      border: 1px solid rgba(63, 81, 181, 0.12);
+      box-shadow: 0 24px 60px -52px rgba(35, 48, 68, 0.8);
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      color: var(--muted);
+    }
+
+    .highlight-card i {
+      font-size: 1.8rem;
+      color: var(--primary);
+    }
+
+    .highlight-card h3 {
+      font-size: 1.2rem;
+      color: var(--text);
+    }
+
+    .highlight-card ul {
+      list-style: none;
+      display: grid;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .timeline {
+      position: relative;
+      margin-top: 24px;
+      display: grid;
+      gap: 28px;
+      padding-left: 24px;
+    }
+
+    .timeline::before {
+      content: '';
+      position: absolute;
+      top: 8px;
+      bottom: 8px;
+      left: 140px;
+      width: 2px;
+      background: linear-gradient(180deg, rgba(63, 81, 181, 0.5), rgba(63, 81, 181, 0));
+    }
+
+    .timeline-item {
+      position: relative;
+      display: grid;
+      grid-template-columns: 160px 1fr;
+      gap: 28px;
+      align-items: start;
+    }
+
+    .timeline-date {
+      text-align: right;
+      font-weight: 700;
+      color: var(--primary);
+      font-size: 1rem;
+      padding-top: 16px;
+    }
+
+    .timeline-date .date-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: rgba(63, 81, 181, 0.12);
+      color: var(--primary);
+      font-size: 0.82rem;
+      margin-top: 8px;
+    }
+
+    .timeline-card {
+      position: relative;
+      background: #fff;
+      border-radius: 22px;
+      padding: 28px;
+      border: 1px solid rgba(63, 81, 181, 0.14);
+      box-shadow: 0 26px 64px -50px rgba(35, 48, 68, 0.7);
+    }
+
+    .timeline-card::before {
+      content: '';
+      position: absolute;
+      left: -41px;
+      top: 32px;
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: var(--surface);
+      border: 3px solid var(--primary);
+      box-shadow: 0 0 0 6px rgba(63, 81, 181, 0.15);
+    }
+
+    .timeline-card h3 {
+      font-size: 1.25rem;
+      color: var(--text);
+      margin-bottom: 12px;
+    }
+
+    .change-list {
+      list-style: none;
+      display: grid;
+      gap: 18px;
+      color: var(--muted);
+    }
+
+    .change-list li {
+      background: rgba(63, 81, 181, 0.04);
+      border-radius: 16px;
+      padding: 16px 18px;
+      border: 1px solid rgba(63, 81, 181, 0.08);
+    }
+
+    .change-list li strong {
+      font-size: 1.05rem;
+      color: var(--text);
+    }
+
+    .change-list li p {
+      margin: 8px 0;
+      color: var(--muted);
+    }
+
+    .link-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .commit-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: rgba(63, 81, 181, 0.12);
+      color: var(--primary);
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: background 0.2s ease, transform 0.2s ease;
+    }
+
+    .commit-link i {
+      font-size: 0.85rem;
+    }
+
+    .commit-link:hover {
+      background: rgba(63, 81, 181, 0.2);
+      transform: translateY(-1px);
+    }
+
+    pre {
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 20px;
+      border-radius: 18px;
+      overflow-x: auto;
+      font-family: 'Fira Code', 'Source Code Pro', monospace;
+      font-size: 0.95rem;
+      line-height: 1.6;
+      margin-top: 16px;
+    }
+
+    code {
+      font-family: inherit;
+    }
+
+    @media (max-width: 960px) {
+      header {
+        padding: 68px 16px 108px;
+      }
+
+      main {
+        margin: -60px auto 80px;
+      }
+
+      section {
+        padding: 30px;
+      }
+
+      .timeline::before {
+        left: 120px;
+      }
+
+      .timeline-item {
+        grid-template-columns: 140px 1fr;
+        gap: 24px;
+      }
+    }
+
+    @media (max-width: 720px) {
+      header {
+        padding: 64px 16px 96px;
+      }
+
+      .top-nav {
+        justify-content: center;
+      }
+
+      .timeline {
+        padding-left: 0;
+      }
+
+      .timeline::before {
+        display: none;
+      }
+
+      .timeline-item {
+        grid-template-columns: 1fr;
+        gap: 14px;
+      }
+
+      .timeline-card::before {
+        left: 24px;
+      }
+
+      .timeline-date {
+        text-align: left;
+        padding-top: 0;
+      }
+    }
+
+    @media (max-width: 520px) {
+      section {
+        padding: 24px;
+      }
+
+      h2 {
+        padding-left: 56px;
+        font-size: 1.35rem;
+      }
+
+      h2 i {
+        width: 38px;
+        height: 38px;
+      }
+
+      .change-list li {
+        padding: 14px 16px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="header-inner">
+      <nav class="top-nav" aria-label="補助ナビゲーション">
+        <a href="index.html"><i class="fas fa-download"></i> インストールガイド</a>
+        <a href="about.html"><i class="fas fa-info-circle"></i> アプリ紹介</a>
+        <a href="usage.html"><i class="fas fa-book-open"></i> 使い方ガイド</a>
+        <a href="updates.html" aria-current="page"><i class="fas fa-clock-rotate-left"></i> 更新履歴</a>
+        <a href="https://github.com/akiii2024/location_memo" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub</a>
+      </nav>
+      <h1>Location Memo 更新履歴</h1>
+      <p class="lead">GitHubのコミット履歴をもとに、Location Memoドキュメントサイトの更新内容を整理しました。新しいページの追加やデザイン改善の経緯を確認できます。</p>
+      <div class="header-stats">
+        <span><i class="fas fa-calendar-day"></i> 最終更新: 2025年9月21日</span>
+        <span><i class="fas fa-code-branch"></i> 主な更新: ドキュメント拡充 / UI改善</span>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="summary">
+      <h2><i class="fas fa-clipboard-list"></i> 最近のハイライト</h2>
+      <p>Location Memoのドキュメントは、2025年夏以降のコミットによって大幅に拡充されました。以下では最新のトピックをまとめています。</p>
+      <div class="highlight-grid">
+        <div class="highlight-card">
+          <i class="fas fa-book-open"></i>
+          <h3>ドキュメントの拡充</h3>
+          <p>利用者向けに、使い方とアプリ紹介の専用ページを公開しました。インストール手順と合わせて、アプリの全体像を把握しやすくなっています。</p>
+          <ul>
+            <li>2025年9月21日: 使い方ガイドページを追加。</li>
+            <li>2025年9月20日: アプリ紹介ページを新設。</li>
+          </ul>
+        </div>
+        <div class="highlight-card">
+          <i class="fas fa-palette"></i>
+          <h3>UI / UX 改善</h3>
+          <p>ヘッダーの視認性や目次アイコンのずれを解消し、全体的なデザインを刷新しました。閲覧性と操作性を高める更新が継続的に行われています。</p>
+          <ul>
+            <li>2025年9月20日: 目次アイコンの揃えやヒーローセクションの重なりを修正。</li>
+            <li>2025年9月18日: セクションごとの演出や進捗バーなどを導入。</li>
+          </ul>
+        </div>
+        <div class="highlight-card">
+          <i class="fas fa-map-signs"></i>
+          <h3>コンテンツの整備</h3>
+          <p>動作確認済み端末の情報やお問い合わせ導線を整備し、初期コミットから継続して内容を充実させています。</p>
+          <ul>
+            <li>2025年7月19日: 目次セクションと動作確認情報を追記。</li>
+            <li>2025年7月18日: 初期構成を整備し、余分なHTMLを整理。</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="timeline">
+      <h2><i class="fas fa-clock-rotate-left"></i> 更新タイムライン</h2>
+      <p>GitHubリポジトリ <a href="https://github.com/akiii2024/location_memo" target="_blank" rel="noopener">akiii2024/location_memo</a> のコミット履歴から、主な更新を時系列で抜粋しています。</p>
+      <div class="timeline">
+        <article class="timeline-item">
+          <div class="timeline-date">
+            <div>2025年9月21日</div>
+            <div class="date-badge"><i class="fas fa-star"></i> 最新</div>
+          </div>
+          <div class="timeline-card">
+            <h3>使い方ガイドを公開し、見出しレイアウトを調整</h3>
+            <p>ユーザーがアプリの操作手順を一望できるように、詳細な使い方ページを追加。見出し周りの余白バランスも整え、読みやすさを向上しました。</p>
+            <ul class="change-list">
+              <li>
+                <strong>使い方ガイドの追加と見出し調整</strong>
+                <p>ステップごとの操作手順や活用ポイントをまとめた新ページを公開し、既存ページの見出し位置も合わせて微調整しました。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/60ae2307b7c81cec9ff666a91deca2f9f80cd038" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit 60ae230</a>
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/pull/6" target="_blank" rel="noopener"><i class="fas fa-code-branch"></i> PR #6</a>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="timeline-item">
+          <div class="timeline-date">
+            <div>2025年9月20日</div>
+          </div>
+          <div class="timeline-card">
+            <h3>アプリ紹介ページを中心にドキュメントを拡張</h3>
+            <p>Location Memoの特徴や導入メリットをまとめた専用ページを公開。合わせて、ヘッダーの視認性や目次アイコンの整列など細かな調整を実施しました。</p>
+            <ul class="change-list">
+              <li>
+                <strong>アプリ紹介ページの新設</strong>
+                <p>機能概要、導入メリット、今後のロードマップなど、アプリ全体を俯瞰できるコンテンツを追加しました。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/c48c0a07591cc836b44e5ae1616d6f450dce93c8" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit c48c0a0</a>
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/pull/5" target="_blank" rel="noopener"><i class="fas fa-code-branch"></i> PR #5</a>
+                </div>
+              </li>
+              <li>
+                <strong>ヘッダーリード文の視認性向上</strong>
+                <p>トップページの導入テキストを白に変更し、背景とのコントラストを高めて情報を読み取りやすくしました。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/ee198db2f13aba57d486211d36d0ec42947b1d0d" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit ee198db</a>
+                </div>
+              </li>
+              <li>
+                <strong>目次アイコンの位置ずれを解消</strong>
+                <p>目次バッジのアイコンが上下にずれる問題を修正し、デバイスを問わず揃って見えるように調整しました。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/dc06a4d7b0bcd072a8579f8e4310ef42821ce4bb" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit dc06a4d</a>
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/c804857fb5d6a3ac5216555e46dc789a6e283e52" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit c804857</a>
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/pull/3" target="_blank" rel="noopener"><i class="fas fa-code-branch"></i> PR #3</a>
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/pull/4" target="_blank" rel="noopener"><i class="fas fa-code-branch"></i> PR #4</a>
+                </div>
+              </li>
+              <li>
+                <strong>ヒーローセクションの重なり問題を修正</strong>
+                <p>ヘッダーの装飾がコンテンツを隠してしまう不具合を解消し、本文が正しく表示されるようにしました。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/bb549ba59490efa97e439425a6e5b4a8b4d0f3bd" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit bb549ba</a>
+                </div>
+              </li>
+              <li>
+                <strong>インストールガイド全体のレイアウト刷新</strong>
+                <p>ページ構造を再設計し、カード型セクションやアニメーション、スクロール補助などを導入しました。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/d0cddaf7ef2d9c31fd4664d4c6990c9f65a13ee6" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit d0cddaf</a>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="timeline-item">
+          <div class="timeline-date">
+            <div>2025年9月18日</div>
+          </div>
+          <div class="timeline-card">
+            <h3>デザインアップデートとお問い合わせ情報の更新</h3>
+            <p>ガイドのUIを大幅に改善しつつ、連絡先となるメールアドレスを最新の情報に差し替えました。</p>
+            <ul class="change-list">
+              <li>
+                <strong>デザインと動線の大幅な改修</strong>
+                <p>目次のアニメーションやFAQのアコーディオン化など、ユーザー体験を高める更新を一括で実施しました。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/2257f789ffce6e32c97bf247f2c35870d2b750a3" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit 2257f78</a>
+                </div>
+              </li>
+              <li>
+                <strong>お問い合わせメールアドレスの変更</strong>
+                <p>ガイド内の連絡先を最新のメールアドレスに更新し、サポート窓口への導線を明確化しました。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/66aa667e76d48f460435ad13955d18d5ba877c6a" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit 66aa667</a>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="timeline-item">
+          <div class="timeline-date">
+            <div>2025年7月19日</div>
+          </div>
+          <div class="timeline-card">
+            <h3>目次セクションと動作確認情報を追加</h3>
+            <p>インストールガイドの構成を整理し、情報を探しやすくするための目次や動作確認済み端末の一覧を整備しました。</p>
+            <ul class="change-list">
+              <li>
+                <strong>目次の追加とレイアウト調整</strong>
+                <p>セクションごとのリンクをまとめた目次を設置し、レイアウト微調整でナビゲーションを改善しました。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/ba55cb08ae9baa9f4f15c8fbc2b6e6568ef1ed1c" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit ba55cb0</a>
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/6192bdf84b86e55034e9d7565a79259fe7f99379" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit 6192bdf</a>
+                </div>
+              </li>
+              <li>
+                <strong>ガイド本文のアップデート</strong>
+                <p>動作確認済み端末リストを追加し、お問い合わせセクションを新設するなど、実運用を意識した内容に更新しました。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/7d9619c29c5de147fc74155a472528113a5dd7fc" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit 7d9619c</a>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="timeline-item">
+          <div class="timeline-date">
+            <div>2025年7月18日</div>
+          </div>
+          <div class="timeline-card">
+            <h3>プロジェクトの初期セットアップ</h3>
+            <p>Location Memo ドキュメントの初期構成を整え、不要となった旧インストールガイドのHTMLファイルを整理しました。</p>
+            <ul class="change-list">
+              <li>
+                <strong>旧インストールガイドの整理</strong>
+                <p>初期実装から不要になったガイドファイルを削除し、リポジトリ構成をシンプルにしました。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/5ada5ead3161b2ebaf202b4092f38983f419ec2c" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit 5ada5ea</a>
+                </div>
+              </li>
+              <li>
+                <strong>初回コミット</strong>
+                <p>Location Memo ガイドのベースとなるコンテンツと構造を追加した最初のコミットです。</p>
+                <div class="link-list">
+                  <a class="commit-link" href="https://github.com/akiii2024/location_memo/commit/9aea346d4f7c6d4d5549ccf5c3b209a303f4a60d" target="_blank" rel="noopener"><i class="fas fa-code"></i> commit 9aea346</a>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="how-to-check">
+      <h2><i class="fas fa-terminal"></i> 自分で更新履歴を確認する</h2>
+      <p>最新の変更点は、GitHub上のコミットやプルリクエストから確認できます。ローカルにリポジトリを取得して履歴を追う場合は、次のコマンドが便利です。</p>
+      <pre><code>git clone https://github.com/akiii2024/location_memo.git
+cd location_memo
+git log --oneline --graph --decorate</code></pre>
+      <p>Webブラウザーから確認する場合は、<a href="https://github.com/akiii2024/location_memo/commits/main" target="_blank" rel="noopener">コミット一覧ページ</a>をご覧ください。</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/usage.html
+++ b/usage.html
@@ -427,6 +427,7 @@
         <a href="index.html"><i class="fas fa-download"></i> インストールガイド</a>
         <a href="about.html"><i class="fas fa-info-circle"></i> アプリ紹介</a>
         <a href="usage.html" aria-current="page"><i class="fas fa-book-open"></i> 使い方ガイド</a>
+        <a href="updates.html"><i class="fas fa-clock-rotate-left"></i> 更新履歴</a>
         <a href="https://github.com/akiii2024/location_memo" target="_blank" rel="noopener"><i class="fab fa-github"></i> GitHub</a>
       </nav>
       <h1>Location Memo 使い方ガイド</h1>


### PR DESCRIPTION
## Summary
- GitHub のコミット履歴から主要な更新内容を整理した更新履歴ページ (`updates.html`) を新規作成しました
- 既存ページのヘッダーナビゲーションに更新履歴ページへのリンクを追加しました

## Testing
- not run (static HTML only)


------
https://chatgpt.com/codex/tasks/task_e_68d09dd9c43c8331bd41f7c276ea2506