### PR TITLE
Fix heading icon alignment on about and updates pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -147,7 +147,7 @@
 
     h2 {
       position: relative;
-      padding-left: 68px;
+      padding-left: 64px;
       font-size: 1.65rem;
       color: var(--primary);
       margin-bottom: 22px;
@@ -167,9 +167,17 @@
       display: grid;
       place-items: center;
       background: rgba(63, 81, 181, 0.1);
+      font-size: 1.2rem;
       color: var(--primary);
       line-height: 1;
       box-shadow: 0 18px 32px -28px rgba(63, 81, 181, 0.65);
+    }
+
+    h2 i::before {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
     }
 
     p {
@@ -178,7 +186,7 @@
     }
 
     section > p {
-      margin-left: 68px;
+      margin-left: 64px;
     }
 
     .feature-grid,

--- a/updates.html
+++ b/updates.html
@@ -153,7 +153,7 @@
 
     h2 {
       position: relative;
-      padding-left: 68px;
+      padding-left: 64px;
       font-size: 1.65rem;
       color: var(--primary);
       margin-bottom: 22px;
@@ -167,15 +167,22 @@
       left: 0;
       top: 50%;
       transform: translateY(-50%);
-      width: 44px;
-      height: 44px;
-      border-radius: 14px;
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
       background: rgba(63, 81, 181, 0.12);
       display: grid;
       place-items: center;
       font-size: 1.2rem;
       color: var(--primary);
       line-height: 1;
+    }
+
+    h2 i::before {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
     }
 
     p {


### PR DESCRIPTION
## Summary
- align the about and updates section heading styles with the installation guide
- adjust heading padding and icon sizing for consistent centering
- add pseudo-element centering to font awesome icons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0a2485bf0833182a08fdcce34be5b